### PR TITLE
【修改】nmea_parser_real_push函数中解析失败内存泄漏问题。

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -181,6 +181,7 @@ int nmea_parser_real_push(nmeaPARSER *parser, const char *buff, int buff_sz)
                     (const char *)parser->buffer + nparsed,
                     sen_sz, (nmeaGPGGA *)node->pack))
                 {
+                    rt_free(node->pack);
                     rt_free(node);
                     node = 0;
                 }
@@ -193,6 +194,7 @@ int nmea_parser_real_push(nmeaPARSER *parser, const char *buff, int buff_sz)
                     (const char *)parser->buffer + nparsed,
                     sen_sz, (nmeaGPGSA *)node->pack))
                 {
+                    rt_free(node->pack);
                     rt_free(node);
                     node = 0;
                 }
@@ -205,6 +207,7 @@ int nmea_parser_real_push(nmeaPARSER *parser, const char *buff, int buff_sz)
                     (const char *)parser->buffer + nparsed,
                     sen_sz, (nmeaGPGSV *)node->pack))
                 {
+                    rt_free(node->pack);
                     rt_free(node);
                     node = 0;
                 }
@@ -217,6 +220,7 @@ int nmea_parser_real_push(nmeaPARSER *parser, const char *buff, int buff_sz)
                     (const char *)parser->buffer + nparsed,
                     sen_sz, (nmeaGPRMC *)node->pack))
                 {
+                    rt_free(node->pack);
                     rt_free(node);
                     node = 0;
                 }
@@ -229,6 +233,7 @@ int nmea_parser_real_push(nmeaPARSER *parser, const char *buff, int buff_sz)
                     (const char *)parser->buffer + nparsed,
                     sen_sz, (nmeaGPVTG *)node->pack))
                 {
+                    rt_free(node->pack);
                     rt_free(node);
                     node = 0;
                 }


### PR DESCRIPTION
nmea_parser_real_push函数中解析失败只释放了node节点，没有释放node->pack节点，从而导致内存泄漏。